### PR TITLE
fixed issue that made it impossible to ser warning to false

### DIFF
--- a/mib2high.py
+++ b/mib2high.py
@@ -7,6 +7,7 @@ import os
 import utils
 import shutil
 import xml.etree.cElementTree as cElementTree
+from distutils.util import strtobool
 from PIL import Image
 '''
 
@@ -79,7 +80,7 @@ class MIB2HIGH(object):
     icon=d['Icon']
     name=d['Name']
 
-    warning=1 if warning else 0
+    warning=strtobool(warning)
 
     cursor = self.conn.cursor()
 

--- a/mib2tsd.py
+++ b/mib2tsd.py
@@ -8,6 +8,7 @@ import utils
 import shutil
 from morton import encode_morton_code, decode_morton_code
 from PIL import Image
+from distutils.util import strtobool
 
 '''
 Amundsen:
@@ -70,7 +71,7 @@ class MIB2TSD(object):
     catid=2001 if lastcatid is None else lastcatid+1
 
     categoryname=name
-    categorywarn=1 if warning else 0
+    categorywarn=strtobool(warning)
 
     src_icon=icon
     (_,icon_extension) = os.path.splitext(src_icon)


### PR DESCRIPTION
Setting warning to False did yield the same result as setting it to True, since the check was done if the variable was created or not. It wasn't possible to leave the wariable out either, since that threw an error