### PR TITLE
fix: Python parse CSV ignoring comma with double-quotes

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -82,7 +82,7 @@ def read_geo_csv(source):
   '''
 
   # Read the 1st row to establish if there is a header or not
-  df = pandas.read_csv(source,header=None,nrows=1)
+  df = pandas.read_csv(source,header=None,nrows=1,quoting=csv.QUOTE_ALL)
 
   if len(df.columns)<3:
     raise Exception("Expected at least 3 columns csv file %s, got %d" % (source,len(df.columns)))
@@ -91,10 +91,10 @@ def read_geo_csv(source):
     # does not have a header, we assume the fields are long,lat,name
     if len(df.columns)!=3:
       raise Exception("Expected 3 columns in headerless csv file %s, got %d" % (source,len(df.columns)))
-    return pandas.read_csv(source,quotechar='"',skipinitialspace=True,header=None,names=[ 'long', 'lat', 'name' ])
+    return pandas.read_csv(source,quotechar='"',skipinitialspace=True,header=None,names=[ 'long', 'lat', 'name' ],quoting=csv.QUOTE_ALL)
   else:
     # has a header
-    df = pandas.read_csv(source,quotechar='"',skipinitialspace=True)
+    df = pandas.read_csv(source,quotechar='"',skipinitialspace=True,quoting=csv.QUOTE_ALL)
     print ("Found Columns: %s" % df.columns)
 
     # Some CSVs have a leading ';' before the header - remove it


### PR DESCRIPTION
I had an issue with: 
```
BUILD_csv_h/GATSO_ALL_h.csv:40463:3.82251,43.631954,"max @50","GRABELS vers JUVIGNAC \"Avenue de l'Europe, face \"\"Les Milles et une Choses\""
```
and:
```
BUILD_csv_h/GATSO_ALL_h.csv:40463:3.82251,43.631954,"max @50","GRABELS vers JUVIGNAC \"Avenue de l'Europe\, face \"\"Les Milles et une Choses\""
```

I found the fix on: 
https://stackoverflow.com/questions/21527057/python-parse-csv-ignoring-comma-with-double-quotes