### PR TITLE
Various fixes

### DIFF
--- a/mib2tsd.py
+++ b/mib2tsd.py
@@ -103,6 +103,9 @@ class MIB2TSD(object):
 
     print('Read %d entries' % len(df))
 
+    if (len(df) == 0):
+      return
+
     df['mortonCode']=df.apply(lambda x: encode_morton_code(x['lat'],x['long']),axis=1)
 
     # Build the poiaddr table

--- a/utils.py
+++ b/utils.py
@@ -101,7 +101,8 @@ def read_geo_csv(source):
   csv_opts={ 'comment':';',
              'quotechar':'"',
              'escapechar':'\\',
-             'skipinitialspace':True }
+             'skipinitialspace':True,
+             'encoding': 'utf8' }
 
   # Read the 1st row to establish if there is a header or not
   df = pandas.read_csv(source,header=None,nrows=1,**csv_opts)


### PR DESCRIPTION
The following PR fixes two different issues I've found when using it with my own set of data:

* When creating a set of data, `mib2tsd` fails if the CSV is empty (while `mib2high` just works fine). This is due to the `df.apply` used for morton codes; but since there are no data anyway, an early `return` fixed it.

* When using `python2`, strings are by default 8-bit strings and not unicode. Adding an `encoding` property fixes the issue.